### PR TITLE
chore: add agent-base submodule, Claude workflows, and architecture docs

### DIFF
--- a/.claude/agents/base.md
+++ b/.claude/agents/base.md
@@ -1,0 +1,1 @@
+../../.agent-base/.claude/agents/base.md

--- a/.claude/agents/pr-description-overrides.md
+++ b/.claude/agents/pr-description-overrides.md
@@ -1,0 +1,11 @@
+# Inherits: .agent-base/.claude/agents/pr-description.md
+# PR Description Overrides — repo-specific
+
+## Repo-Specific Risk Flags
+
+Always mention in the Risk section when applicable:
+
+- **New dependencies** — must justify, pin exact version, `npm audit` / equivalent clean
+- **Auth/security changes** — must be reviewed by security-aware reviewer
+- **Database schema changes** — migration risk, backward compatibility
+- **API contract changes** — breaking change risk, versioning

--- a/.claude/agents/pr-description.md
+++ b/.claude/agents/pr-description.md
@@ -1,0 +1,1 @@
+../../.agent-base/.claude/agents/pr-description.md

--- a/.claude/agents/pr-learnings-overrides.md
+++ b/.claude/agents/pr-learnings-overrides.md
@@ -1,0 +1,11 @@
+# Inherits: .agent-base/.claude/agents/pr-learnings.md
+# PR Learnings Overrides — repo-specific
+
+## Scan Focus
+
+When scanning PR history, pay special attention to:
+
+- Fix-after-fix chains (multiple commits fixing the same issue)
+- Missing error handling that caused production incidents
+- Security issues that were caught late in review
+- Performance regressions from N+1 patterns or unbounded queries

--- a/.claude/agents/pr-learnings.md
+++ b/.claude/agents/pr-learnings.md
@@ -1,0 +1,1 @@
+../../.agent-base/.claude/agents/pr-learnings.md

--- a/.claude/agents/refactor-overrides.md
+++ b/.claude/agents/refactor-overrides.md
@@ -1,0 +1,9 @@
+# Inherits: .agent-base/.claude/agents/refactor.md
+# Refactor Overrides — repo-specific
+
+## Repo-Specific Refactoring Rules
+
+- Identify and flag any large monolithic files (>500 lines) for decomposition
+- Check for N+1 query patterns and suggest batch alternatives
+- Look for duplicated logic that could be extracted into shared utilities
+- Ensure all new abstractions are justified (no premature abstraction)

--- a/.claude/agents/refactor.md
+++ b/.claude/agents/refactor.md
@@ -1,0 +1,1 @@
+../../.agent-base/.claude/agents/refactor.md

--- a/.claude/agents/review-overrides.md
+++ b/.claude/agents/review-overrides.md
@@ -1,0 +1,10 @@
+# Inherits: .agent-base/.claude/agents/review.md
+# PR Review Overrides — repo-specific
+
+## Repo-Specific Review Checks
+
+- Verify all new endpoints/handlers enforce authentication
+- Check for hardcoded secrets, API keys, or credentials
+- Ensure error handling uses greppable error codes (SOURCE_OPERATION_FAILURE pattern)
+- Confirm input validation at API boundaries
+- Check that no PII or sensitive data is logged at INFO level or above

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -1,0 +1,1 @@
+../../.agent-base/.claude/agents/review.md

--- a/.claude/agents/test-coverage-overrides.md
+++ b/.claude/agents/test-coverage-overrides.md
@@ -1,0 +1,10 @@
+# Inherits: .agent-base/.claude/agents/test-coverage.md
+# Test Coverage Overrides — repo-specific
+
+## Repo-Specific Testing Rules
+
+- Test happy path + at least 2 edge cases per function
+- Test with undefined/null inputs, empty arrays, empty objects
+- Test error scenarios: timeouts, 500s, malformed responses
+- Mock at the boundary (API clients, external services), not internal functions
+- Test names should read as specifications

--- a/.claude/agents/test-coverage.md
+++ b/.claude/agents/test-coverage.md
@@ -1,0 +1,1 @@
+../../.agent-base/.claude/agents/test-coverage.md

--- a/.claude/skills/stacked-prs/SKILL.md
+++ b/.claude/skills/stacked-prs/SKILL.md
@@ -1,0 +1,1 @@
+../../../.agent-base/.claude/skills/stacked-prs/SKILL.md

--- a/.claude/skills/testing-principles/SKILL.md
+++ b/.claude/skills/testing-principles/SKILL.md
@@ -1,0 +1,1 @@
+../../../.agent-base/.claude/skills/testing-principles/SKILL.md

--- a/.github/workflows/claude-refactor.yml
+++ b/.github/workflows/claude-refactor.yml
@@ -82,7 +82,7 @@ jobs:
           anthropic_api_key: ${{ steps.ssm.outputs.anthropic-api-key }}
           base_branch: main
           prompt: ${{ steps.instructions.outputs.prompt }}
-          claude_args: '--max-turns 50 --dangerously-skip-permissions --allowedTools "Edit,Write,Read,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(find:*),Bash(grep:*),Bash(cat:*),Bash(ls:*)"'
+          claude_args: '--max-turns 50 --dangerously-skip-permissions --allowedTools "Edit,Write,Read,Bash(git:*),Bash(gh:*),Bash(go:*),Bash(make:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(find:*),Bash(grep:*),Bash(cat:*),Bash(ls:*)"'
           show_full_output: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/claude-refactor.yml
+++ b/.github/workflows/claude-refactor.yml
@@ -1,0 +1,86 @@
+name: "Claude: Refactor Agent"
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  refactor:
+    if: github.event.label.name == 'claude-refactor'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Fetch secrets from SSM
+        id: ssm
+        run: |
+          ANTHROPIC_API_KEY=$(aws ssm get-parameter --name "/ci/anthropic/api-key" --with-decryption --query "Parameter.Value" --output text)
+          APP_ID=$(aws ssm get-parameter --name "/ci/create-github-app-token/app-id" --with-decryption --query "Parameter.Value" --output text)
+          APP_PRIVATE_KEY=$(aws ssm get-parameter --name "/ci/create-github-app-token/private-key" --with-decryption --query "Parameter.Value" --output text)
+          echo "::add-mask::$ANTHROPIC_API_KEY"
+          echo "::add-mask::$APP_PRIVATE_KEY"
+          echo "anthropic-api-key=$ANTHROPIC_API_KEY" >> "$GITHUB_OUTPUT"
+          echo "app-id=$APP_ID" >> "$GITHUB_OUTPUT"
+          {
+            echo "app-private-key<<PRIVATE_KEY_EOF"
+            echo "$APP_PRIVATE_KEY"
+            echo "PRIVATE_KEY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ steps.ssm.outputs.app-id }}
+          private-key: ${{ steps.ssm.outputs.app-private-key }}
+          owner: ${{ github.repository_owner }}
+          repositories: "${{ github.event.repository.name }},agent-base"
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Load agent instructions
+        id: instructions
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          DELIMITER="AGENT_EOF_$(openssl rand -hex 16)"
+          {
+            echo "prompt<<$DELIMITER"
+            echo "REPO: ${{ github.repository }}"
+            echo "ISSUE NUMBER: ${{ github.event.issue.number }}"
+            echo "ISSUE TITLE: $ISSUE_TITLE"
+            echo ""
+            if [ -f .claude/agents/base.md ]; then cat .claude/agents/base.md; echo ""; fi
+            if [ -f .claude/agents/refactor.md ]; then cat .claude/agents/refactor.md; echo ""; fi
+            echo "---"
+            echo ""
+            echo "## Issue Description"
+            echo ""
+            echo "$ISSUE_BODY"
+            echo "$DELIMITER"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ steps.ssm.outputs.anthropic-api-key }}
+          base_branch: main
+          prompt: ${{ steps.instructions.outputs.prompt }}
+          claude_args: '--max-turns 50 --dangerously-skip-permissions --allowedTools "Edit,Write,Read,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(find:*),Bash(grep:*),Bash(cat:*),Bash(ls:*)"'
+          show_full_output: true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/claude-refactor.yml
+++ b/.github/workflows/claude-refactor.yml
@@ -31,10 +31,11 @@ jobs:
           echo "::add-mask::$APP_PRIVATE_KEY"
           echo "anthropic-api-key=$ANTHROPIC_API_KEY" >> "$GITHUB_OUTPUT"
           echo "app-id=$APP_ID" >> "$GITHUB_OUTPUT"
+          DELIMITER="PRIVKEY_EOF_$(openssl rand -hex 16)"
           {
-            echo "app-private-key<<PRIVATE_KEY_EOF"
+            echo "app-private-key<<$DELIMITER"
             echo "$APP_PRIVATE_KEY"
-            echo "PRIVATE_KEY_EOF"
+            echo "$DELIMITER"
           } >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub App token
@@ -67,6 +68,7 @@ jobs:
             echo ""
             if [ -f .claude/agents/base.md ]; then cat .claude/agents/base.md; echo ""; fi
             if [ -f .claude/agents/refactor.md ]; then cat .claude/agents/refactor.md; echo ""; fi
+            if [ -f .claude/agents/refactor-overrides.md ]; then echo ""; cat .claude/agents/refactor-overrides.md; fi
             echo "---"
             echo ""
             echo "## Issue Description"

--- a/.github/workflows/claude-refactor.yml
+++ b/.github/workflows/claude-refactor.yml
@@ -28,7 +28,7 @@ jobs:
           APP_ID=$(aws ssm get-parameter --name "/ci/create-github-app-token/app-id" --with-decryption --query "Parameter.Value" --output text)
           APP_PRIVATE_KEY=$(aws ssm get-parameter --name "/ci/create-github-app-token/private-key" --with-decryption --query "Parameter.Value" --output text)
           echo "::add-mask::$ANTHROPIC_API_KEY"
-          echo "::add-mask::$APP_PRIVATE_KEY"
+          while IFS= read -r line; do echo "::add-mask::$line"; done <<< "$APP_PRIVATE_KEY"
           echo "anthropic-api-key=$ANTHROPIC_API_KEY" >> "$GITHUB_OUTPUT"
           echo "app-id=$APP_ID" >> "$GITHUB_OUTPUT"
           DELIMITER="PRIVKEY_EOF_$(openssl rand -hex 16)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -38,10 +38,11 @@ jobs:
           echo "::add-mask::$APP_PRIVATE_KEY"
           echo "anthropic-api-key=$ANTHROPIC_API_KEY" >> "$GITHUB_OUTPUT"
           echo "app-id=$APP_ID" >> "$GITHUB_OUTPUT"
+          DELIMITER="PRIVKEY_EOF_$(openssl rand -hex 16)"
           {
-            echo "app-private-key<<PRIVATE_KEY_EOF"
+            echo "app-private-key<<$DELIMITER"
             echo "$APP_PRIVATE_KEY"
-            echo "PRIVATE_KEY_EOF"
+            echo "$DELIMITER"
           } >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub App token
@@ -64,6 +65,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           else
             echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
           fi
@@ -78,7 +81,8 @@ jobs:
             echo "PR NUMBER: ${{ steps.pr.outputs.number }}"
             echo ""
             if [ -f .claude/agents/base.md ]; then cat .claude/agents/base.md; echo ""; fi
-            if [ -f .claude/agents/review.md ]; then cat .claude/agents/review.md; fi
+            if [ -f .claude/agents/review.md ]; then cat .claude/agents/review.md; echo ""; fi
+            if [ -f .claude/agents/review-overrides.md ]; then echo ""; cat .claude/agents/review-overrides.md; fi
             echo "$DELIMITER"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -70,6 +70,8 @@ jobs:
             echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
             echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request_review" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           else
             echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,7 +2,7 @@ name: "Claude: PR Review Agent"
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, ready_for_review]
   issue_comment:
     types: [created]
   pull_request_review_comment:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,13 +7,16 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   review:
     if: |
       (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude-review')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude-review'))
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude-review')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude-review'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -35,7 +38,7 @@ jobs:
           APP_ID=$(aws ssm get-parameter --name "/ci/create-github-app-token/app-id" --with-decryption --query "Parameter.Value" --output text)
           APP_PRIVATE_KEY=$(aws ssm get-parameter --name "/ci/create-github-app-token/private-key" --with-decryption --query "Parameter.Value" --output text)
           echo "::add-mask::$ANTHROPIC_API_KEY"
-          echo "::add-mask::$APP_PRIVATE_KEY"
+          while IFS= read -r line; do echo "::add-mask::$line"; done <<< "$APP_PRIVATE_KEY"
           echo "anthropic-api-key=$ANTHROPIC_API_KEY" >> "$GITHUB_OUTPUT"
           echo "app-id=$APP_ID" >> "$GITHUB_OUTPUT"
           DELIMITER="PRIVKEY_EOF_$(openssl rand -hex 16)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,97 @@
+name: "Claude: PR Review Agent"
+
+on:
+  pull_request:
+    types: [opened]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  review:
+    if: |
+      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude-review')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude-review'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Fetch secrets from SSM
+        id: ssm
+        run: |
+          ANTHROPIC_API_KEY=$(aws ssm get-parameter --name "/ci/anthropic/api-key" --with-decryption --query "Parameter.Value" --output text)
+          APP_ID=$(aws ssm get-parameter --name "/ci/create-github-app-token/app-id" --with-decryption --query "Parameter.Value" --output text)
+          APP_PRIVATE_KEY=$(aws ssm get-parameter --name "/ci/create-github-app-token/private-key" --with-decryption --query "Parameter.Value" --output text)
+          echo "::add-mask::$ANTHROPIC_API_KEY"
+          echo "::add-mask::$APP_PRIVATE_KEY"
+          echo "anthropic-api-key=$ANTHROPIC_API_KEY" >> "$GITHUB_OUTPUT"
+          echo "app-id=$APP_ID" >> "$GITHUB_OUTPUT"
+          {
+            echo "app-private-key<<PRIVATE_KEY_EOF"
+            echo "$APP_PRIVATE_KEY"
+            echo "PRIVATE_KEY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ steps.ssm.outputs.app-id }}
+          private-key: ${{ steps.ssm.outputs.app-private-key }}
+          owner: ${{ github.repository_owner }}
+          repositories: "${{ github.event.repository.name }},agent-base"
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Resolve PR number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Load agent instructions
+        id: instructions
+        run: |
+          DELIMITER="AGENT_EOF_$(openssl rand -hex 16)"
+          {
+            echo "prompt<<$DELIMITER"
+            echo "REPO: ${{ github.repository }}"
+            echo "PR NUMBER: ${{ steps.pr.outputs.number }}"
+            echo ""
+            if [ -f .claude/agents/base.md ]; then cat .claude/agents/base.md; echo ""; fi
+            if [ -f .claude/agents/review.md ]; then cat .claude/agents/review.md; fi
+            echo "$DELIMITER"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ steps.ssm.outputs.anthropic-api-key }}
+          base_branch: main
+          track_progress: true
+          prompt: ${{ steps.instructions.outputs.prompt }}
+          show_full_output: true
+          claude_args: |
+            --max-turns 50
+            --dangerously-skip-permissions
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/claude-test-coverage.yml
+++ b/.github/workflows/claude-test-coverage.yml
@@ -82,7 +82,7 @@ jobs:
           anthropic_api_key: ${{ steps.ssm.outputs.anthropic-api-key }}
           base_branch: main
           prompt: ${{ steps.instructions.outputs.prompt }}
-          claude_args: '--max-turns 50 --dangerously-skip-permissions --allowedTools "Edit,Write,Read,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(find:*),Bash(grep:*),Bash(cat:*),Bash(ls:*)"'
+          claude_args: '--max-turns 50 --dangerously-skip-permissions --allowedTools "Edit,Write,Read,Bash(git:*),Bash(gh:*),Bash(go:*),Bash(make:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(find:*),Bash(grep:*),Bash(cat:*),Bash(ls:*)"'
           show_full_output: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/claude-test-coverage.yml
+++ b/.github/workflows/claude-test-coverage.yml
@@ -1,0 +1,86 @@
+name: "Claude: Test Coverage Agent"
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  test-coverage:
+    if: github.event.label.name == 'claude-test-coverage'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Fetch secrets from SSM
+        id: ssm
+        run: |
+          ANTHROPIC_API_KEY=$(aws ssm get-parameter --name "/ci/anthropic/api-key" --with-decryption --query "Parameter.Value" --output text)
+          APP_ID=$(aws ssm get-parameter --name "/ci/create-github-app-token/app-id" --with-decryption --query "Parameter.Value" --output text)
+          APP_PRIVATE_KEY=$(aws ssm get-parameter --name "/ci/create-github-app-token/private-key" --with-decryption --query "Parameter.Value" --output text)
+          echo "::add-mask::$ANTHROPIC_API_KEY"
+          echo "::add-mask::$APP_PRIVATE_KEY"
+          echo "anthropic-api-key=$ANTHROPIC_API_KEY" >> "$GITHUB_OUTPUT"
+          echo "app-id=$APP_ID" >> "$GITHUB_OUTPUT"
+          {
+            echo "app-private-key<<PRIVATE_KEY_EOF"
+            echo "$APP_PRIVATE_KEY"
+            echo "PRIVATE_KEY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ steps.ssm.outputs.app-id }}
+          private-key: ${{ steps.ssm.outputs.app-private-key }}
+          owner: ${{ github.repository_owner }}
+          repositories: "${{ github.event.repository.name }},agent-base"
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Load agent instructions
+        id: instructions
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          DELIMITER="AGENT_EOF_$(openssl rand -hex 16)"
+          {
+            echo "prompt<<$DELIMITER"
+            echo "REPO: ${{ github.repository }}"
+            echo "ISSUE NUMBER: ${{ github.event.issue.number }}"
+            echo "ISSUE TITLE: $ISSUE_TITLE"
+            echo ""
+            if [ -f .claude/agents/base.md ]; then cat .claude/agents/base.md; echo ""; fi
+            if [ -f .claude/agents/test-coverage.md ]; then cat .claude/agents/test-coverage.md; echo ""; fi
+            echo "---"
+            echo ""
+            echo "## Issue Description"
+            echo ""
+            echo "$ISSUE_BODY"
+            echo "$DELIMITER"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ steps.ssm.outputs.anthropic-api-key }}
+          base_branch: main
+          prompt: ${{ steps.instructions.outputs.prompt }}
+          claude_args: '--max-turns 50 --dangerously-skip-permissions --allowedTools "Edit,Write,Read,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(find:*),Bash(grep:*),Bash(cat:*),Bash(ls:*)"'
+          show_full_output: true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/claude-test-coverage.yml
+++ b/.github/workflows/claude-test-coverage.yml
@@ -28,7 +28,7 @@ jobs:
           APP_ID=$(aws ssm get-parameter --name "/ci/create-github-app-token/app-id" --with-decryption --query "Parameter.Value" --output text)
           APP_PRIVATE_KEY=$(aws ssm get-parameter --name "/ci/create-github-app-token/private-key" --with-decryption --query "Parameter.Value" --output text)
           echo "::add-mask::$ANTHROPIC_API_KEY"
-          echo "::add-mask::$APP_PRIVATE_KEY"
+          while IFS= read -r line; do echo "::add-mask::$line"; done <<< "$APP_PRIVATE_KEY"
           echo "anthropic-api-key=$ANTHROPIC_API_KEY" >> "$GITHUB_OUTPUT"
           echo "app-id=$APP_ID" >> "$GITHUB_OUTPUT"
           DELIMITER="PRIVKEY_EOF_$(openssl rand -hex 16)"

--- a/.github/workflows/claude-test-coverage.yml
+++ b/.github/workflows/claude-test-coverage.yml
@@ -31,10 +31,11 @@ jobs:
           echo "::add-mask::$APP_PRIVATE_KEY"
           echo "anthropic-api-key=$ANTHROPIC_API_KEY" >> "$GITHUB_OUTPUT"
           echo "app-id=$APP_ID" >> "$GITHUB_OUTPUT"
+          DELIMITER="PRIVKEY_EOF_$(openssl rand -hex 16)"
           {
-            echo "app-private-key<<PRIVATE_KEY_EOF"
+            echo "app-private-key<<$DELIMITER"
             echo "$APP_PRIVATE_KEY"
-            echo "PRIVATE_KEY_EOF"
+            echo "$DELIMITER"
           } >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub App token
@@ -67,6 +68,7 @@ jobs:
             echo ""
             if [ -f .claude/agents/base.md ]; then cat .claude/agents/base.md; echo ""; fi
             if [ -f .claude/agents/test-coverage.md ]; then cat .claude/agents/test-coverage.md; echo ""; fi
+            if [ -f .claude/agents/test-coverage-overrides.md ]; then echo ""; cat .claude/agents/test-coverage-overrides.md; fi
             echo "---"
             echo ""
             echo "## Issue Description"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,15 +6,15 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned, labeled]
+    types: [opened]
   pull_request_review:
     types: [submitted]
 
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude-review')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude-review')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
     runs-on: ubuntu-latest
@@ -41,10 +41,11 @@ jobs:
           echo "::add-mask::$APP_PRIVATE_KEY"
           echo "anthropic-api-key=$ANTHROPIC_API_KEY" >> "$GITHUB_OUTPUT"
           echo "app-id=$APP_ID" >> "$GITHUB_OUTPUT"
+          DELIMITER="PRIVKEY_EOF_$(openssl rand -hex 16)"
           {
-            echo "app-private-key<<PRIVATE_KEY_EOF"
+            echo "app-private-key<<$DELIMITER"
             echo "$APP_PRIVATE_KEY"
-            echo "PRIVATE_KEY_EOF"
+            echo "$DELIMITER"
           } >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub App token

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,7 +6,7 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened]
+    types: [opened, assigned]
   pull_request_review:
     types: [submitted]
 
@@ -16,7 +16,7 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude-review')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude-review')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || github.event.action == 'assigned'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,87 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned, labeled]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Fetch secrets from SSM
+        id: ssm
+        run: |
+          ANTHROPIC_API_KEY=$(aws ssm get-parameter --name "/ci/anthropic/api-key" --with-decryption --query "Parameter.Value" --output text)
+          APP_ID=$(aws ssm get-parameter --name "/ci/create-github-app-token/app-id" --with-decryption --query "Parameter.Value" --output text)
+          APP_PRIVATE_KEY=$(aws ssm get-parameter --name "/ci/create-github-app-token/private-key" --with-decryption --query "Parameter.Value" --output text)
+          echo "::add-mask::$ANTHROPIC_API_KEY"
+          echo "::add-mask::$APP_PRIVATE_KEY"
+          echo "anthropic-api-key=$ANTHROPIC_API_KEY" >> "$GITHUB_OUTPUT"
+          echo "app-id=$APP_ID" >> "$GITHUB_OUTPUT"
+          {
+            echo "app-private-key<<PRIVATE_KEY_EOF"
+            echo "$APP_PRIVATE_KEY"
+            echo "PRIVATE_KEY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ steps.ssm.outputs.app-id }}
+          private-key: ${{ steps.ssm.outputs.app-private-key }}
+          owner: ${{ github.repository_owner }}
+          repositories: "${{ github.event.repository.name }},agent-base"
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Load agent instructions
+        id: instructions
+        run: |
+          DELIMITER="AGENT_EOF_$(openssl rand -hex 16)"
+          {
+            echo "prompt<<$DELIMITER"
+            if [ -f .claude/agents/base.md ]; then cat .claude/agents/base.md; echo ""; fi
+            echo ""
+            echo "You also have access to specialized agent instructions in .claude/agents/. If a task matches a specific agent (review, refactor, test-coverage), read the corresponding file for detailed guidance."
+            echo "$DELIMITER"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ steps.ssm.outputs.anthropic-api-key }}
+          base_branch: main
+          prompt: ${{ steps.instructions.outputs.prompt }}
+          trigger_phrase: "@claude"
+          assignee_trigger: "claude"
+          claude_args: '--max-turns 50 --dangerously-skip-permissions --allowedTools "Edit,Write,Read,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(find:*),Bash(grep:*),Bash(cat:*),Bash(ls:*)"'
+          show_full_output: true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,7 +39,7 @@ jobs:
           APP_ID=$(aws ssm get-parameter --name "/ci/create-github-app-token/app-id" --with-decryption --query "Parameter.Value" --output text)
           APP_PRIVATE_KEY=$(aws ssm get-parameter --name "/ci/create-github-app-token/private-key" --with-decryption --query "Parameter.Value" --output text)
           echo "::add-mask::$ANTHROPIC_API_KEY"
-          echo "::add-mask::$APP_PRIVATE_KEY"
+          while IFS= read -r line; do echo "::add-mask::$line"; done <<< "$APP_PRIVATE_KEY"
           echo "anthropic-api-key=$ANTHROPIC_API_KEY" >> "$GITHUB_OUTPUT"
           echo "app-id=$APP_ID" >> "$GITHUB_OUTPUT"
           DELIMITER="PRIVKEY_EOF_$(openssl rand -hex 16)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,8 +15,9 @@ jobs:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude-review')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude-review')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || github.event.action == 'assigned'))
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude-review')) ||
+      (github.event_name == 'issues' && github.event.action == 'opened' && contains(github.event.issue.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.action == 'assigned' && github.event.assignee.login == 'claude')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -82,7 +83,7 @@ jobs:
           prompt: ${{ steps.instructions.outputs.prompt }}
           trigger_phrase: "@claude"
           assignee_trigger: "claude"
-          claude_args: '--max-turns 50 --dangerously-skip-permissions --allowedTools "Edit,Write,Read,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(find:*),Bash(grep:*),Bash(cat:*),Bash(ls:*)"'
+          claude_args: '--max-turns 50 --dangerously-skip-permissions --allowedTools "Edit,Write,Read,Bash(git:*),Bash(gh:*),Bash(go:*),Bash(make:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(find:*),Bash(grep:*),Bash(cat:*),Bash(ls:*)"'
           show_full_output: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ crdschemas/
 
 developer-workspace/gitpod/_output
 developer-workspace/codespaces/kind 
+
+# Track Claude agent configs
+!.claude/agents/
+!.claude/skills/
+.claude/settings.local.json
+.claude/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@ crdschemas/
 developer-workspace/gitpod/_output
 developer-workspace/codespaces/kind 
 
-# Track Claude agent configs
+# Claude Code agent config
+.claude/*
 !.claude/agents/
 !.claude/skills/
 .claude/settings.local.json
-.claude/worktrees/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".agent-base"]
+	path = .agent-base
+	url = https://github.com/GBI-Core/agent-base.git

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,86 @@
+# Architecture — kube-prometheus
+
+> Auto-generated architecture overview. Last updated: 2026-03-20
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| **Repository** | GBI-Core/kube-prometheus |
+| **Primary Language** | Go |
+| **Framework** | github.com/prometheus-operator/kube-prometheus |
+| **Default Branch** | main |
+| **Has Docker** | No |
+| **Has Protobuf** | No |
+
+## Directory Structure
+
+```
+kube-prometheus/
+├── developer-workspace/
+│   ├── codespaces/
+│   ├── common/
+│   ├── gitpod/
+├── docs/
+│   ├── customizations/
+│   ├── migration-example/
+├── examples/
+│   ├── basic-auth/
+│   ├── continuous-delivery/
+│   ├── example-app/
+│   ├── jsonnet-build-snippet/
+│   ├── jsonnet-snippets/
+├── experimental/
+│   ├── metrics-server/
+├── jsonnet/
+│   ├── kube-prometheus/
+├── manifests/
+│   ├── setup/
+├── scripts/
+├── tests/
+│   ├── e2e/
+```
+
+## Source File Distribution
+
+- `.yaml`: 121 files
+- `.go`: 3 files
+- `.yml`: 1 files
+
+## Entry Points
+
+No standard entry points detected. Review repo-specific docs.
+
+## API Definitions
+
+No OpenAPI/Swagger/Protobuf definitions found.
+
+## CI/CD Workflows
+
+- `ci.yaml`
+- `claude-refactor.yml`
+- `claude-review.yml`
+- `claude-test-coverage.yml`
+- `claude.yml`
+- `kind`
+- `stale.yaml`
+- `versions.yaml`
+
+## Infrastructure
+
+No Docker files found at top level.
+
+## Module Dependency Diagram
+
+```mermaid
+graph TD
+    A[source] --> B[modules]
+```
+
+## Key Decisions
+
+_To be populated as architectural decisions are made. See `.agent-base/.claude/guides/decisions/ADR-000-template.md` for the ADR template._
+
+---
+
+*This document is maintained as part of the agent-base infrastructure. Update it when adding/removing modules, API endpoints, or dependencies.*

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,17 +1,27 @@
 # Architecture — kube-prometheus
 
-> Auto-generated architecture overview. Last updated: 2026-03-20
+> Auto-generated on 2026-03-20. Update when adding modules, endpoints, or dependencies.
 
 ## Overview
 
 | Property | Value |
 |----------|-------|
-| **Repository** | GBI-Core/kube-prometheus |
-| **Primary Language** | Go |
+| **Repository** | `GBI-Core/kube-prometheus` |
+| **Language** | Go |
 | **Framework** | github.com/prometheus-operator/kube-prometheus |
-| **Default Branch** | main |
-| **Has Docker** | No |
-| **Has Protobuf** | No |
+| **Default Branch** | `main` |
+| **Dockerized** | No |
+| **Protobuf/gRPC** | No |
+| **Test Command** | `go test ./...` |
+
+## High-Level Architecture
+
+```mermaid
+graph TD
+    subgraph Entry Points
+    end
+
+```
 
 ## Directory Structure
 
@@ -20,40 +30,39 @@ kube-prometheus/
 ├── developer-workspace/
 │   ├── codespaces/
 │   ├── common/
-│   ├── gitpod/
+│   └── gitpod/
 ├── docs/
 │   ├── customizations/
-│   ├── migration-example/
+│   └── migration-example/
 ├── examples/
 │   ├── basic-auth/
 │   ├── continuous-delivery/
 │   ├── example-app/
 │   ├── jsonnet-build-snippet/
-│   ├── jsonnet-snippets/
+│   └── jsonnet-snippets/
 ├── experimental/
-│   ├── metrics-server/
+│   └── metrics-server/
 ├── jsonnet/
-│   ├── kube-prometheus/
+│   └── kube-prometheus/
 ├── manifests/
-│   ├── setup/
+│   └── setup/
 ├── scripts/
 ├── tests/
-│   ├── e2e/
+│   └── e2e/
 ```
 
-## Source File Distribution
+## Source Files
 
-- `.yaml`: 121 files
-- `.go`: 3 files
-- `.yml`: 1 files
+| Extension | Count |
+|-----------|-------|
+| `.yaml` | 121 |
+| `.jsonnet` | 46 |
+| `.go` | 3 |
+| `.yml` | 1 |
 
 ## Entry Points
 
-No standard entry points detected. Review repo-specific docs.
-
-## API Definitions
-
-No OpenAPI/Swagger/Protobuf definitions found.
+No standard entry points detected.
 
 ## CI/CD Workflows
 
@@ -66,21 +75,10 @@ No OpenAPI/Swagger/Protobuf definitions found.
 - `stale.yaml`
 - `versions.yaml`
 
-## Infrastructure
-
-No Docker files found at top level.
-
-## Module Dependency Diagram
-
-```mermaid
-graph TD
-    A[source] --> B[modules]
-```
-
 ## Key Decisions
 
-_To be populated as architectural decisions are made. See `.agent-base/.claude/guides/decisions/ADR-000-template.md` for the ADR template._
+_Populate with ADRs as decisions are made. Template: `.agent-base/.claude/guides/decisions/ADR-000-template.md`_
 
 ---
 
-*This document is maintained as part of the agent-base infrastructure. Update it when adding/removing modules, API endpoints, or dependencies.*
+*Maintained as part of agent-base infrastructure.*


### PR DESCRIPTION
## Summary
- Adds `agent-base` as a git submodule at `.agent-base/`
- Symlinks 6 master agents from agent-base (base, review, refactor, test-coverage, pr-description, pr-learnings)
- Symlinks 2 universal skills (testing-principles, stacked-prs)
- Creates repo-specific override files for all agents
- Adds 4 GitHub Actions workflows for Claude Code integration:
  - `claude.yml` — Generic @claude trigger (issues, comments, reviews)
  - `claude-review.yml` — Auto PR review on open + @claude-review trigger
  - `claude-refactor.yml` — Refactor agent via `claude-refactor` label
  - `claude-test-coverage.yml` — Test coverage agent via `claude-test-coverage` label
- All workflows use `vars.AWS_REGION` org variable and `--max-turns 50`
- Updates `.gitignore` to track `.claude/agents/` and `.claude/skills/`

## Test plan
- [ ] `git clone --recurse-submodules` — verify agent-base submodule initializes
- [ ] `readlink .claude/agents/review.md` → `../../.agent-base/.claude/agents/review.md`
- [ ] Verify workflows reference correct `base_branch`
- [ ] Verify no secrets are hardcoded (all from SSM)

## Risk
**Blast radius:** None — no runtime code changes. Agent infrastructure + CI workflows only.
**Rollback:** Remove submodule, symlinks, overrides, and workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new CI workflows that assume AWS OIDC/SSM access and can write to the repo/PRs; misconfiguration could break automation or expand CI blast radius, though no runtime product code changes.
> 
> **Overview**
> Introduces a new `.agent-base` git submodule and points `.claude/agents/*` and `.claude/skills/*` at the shared agent instructions, with repo-specific override markdowns for review/refactor/test coverage/PR description and learnings.
> 
> Adds four GitHub Actions workflows (`claude.yml`, `claude-review.yml`, `claude-refactor.yml`, `claude-test-coverage.yml`) that fetch secrets from AWS SSM via OIDC, generate a GitHub App token, and run `anthropics/claude-code-action` on PR/issue triggers.
> 
> Updates `.gitignore` to ignore most `.claude` config while keeping agent/skill definitions tracked, and adds `docs/architecture.md` as an autogenerated architecture snapshot.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e44a766a52b6091dbaa7b7f8fd78da6add453586. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->